### PR TITLE
Add IT_DRIVER_LICENSE positive test case

### DIFF
--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -24,7 +24,14 @@ class TestTeam_not_like_us(unittest.TestCase):
         self.assertTrue(len(result)>0, "Result is empty - license not detected")
         self.assertEqual(result[0].entity_type, "IT_DRIVER_LICENSE")
 
-        #Negative Test Case 
+       #Negative Test Case
+        invalid_license = "123456789"
+        result = analyze_text(invalid_license, ["IT_DRIVER_LICENSE"])
+
+        # make sure entity is not detected
+        self.assertEqual(len(result),0)
+        
+
     def test_it_fiscal_code(self):
         """Test IT_FISCAL_CODE functionality"""
 

--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -25,11 +25,16 @@ class TestTeam_not_like_us(unittest.TestCase):
         self.assertEqual(result[0].entity_type, "IT_DRIVER_LICENSE")
 
        #Negative Test Case
-        invalid_license = "123456789"
-        result = analyze_text(invalid_license, ["IT_DRIVER_LICENSE"])
+        
+        invalid_licenes = ["ABC12345", "A1234567Z", "AB12345678",
+         "AB12345", "AB 1234567 Z", "ab1234567z" "@XY1234567Z"]
 
-        # make sure entity is not detected
-        self.assertEqual(len(result),0, "Unexpected entity detected in  invalid license test")
+        for invalid_license in invalid_licenes:
+            result = analyze_text(invalid_license,["IT_DRIVER_LICENSE"])
+
+            #make sure entity is not detected and prevents false negatives
+            if len(result)>0:
+                self.assertLessEqual(result[0].score,0.2, f"Detected invalid license: { invalid_license}-{result}")
         
 
     def test_it_fiscal_code(self):

--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -29,7 +29,7 @@ class TestTeam_not_like_us(unittest.TestCase):
         result = analyze_text(invalid_license, ["IT_DRIVER_LICENSE"])
 
         # make sure entity is not detected
-        self.assertEqual(len(result),0)
+        self.assertEqual(len(result),0, "Unexpected entity detected in  invalid license test")
         
 
     def test_it_fiscal_code(self):

--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -26,7 +26,7 @@ class TestTeam_not_like_us(unittest.TestCase):
 
        #Negative Test Case
         
-        invalid_licenes = ["ABC12345", "A1234567Z", "AB12345678",
+        invalid_licenes = ["123456789","ABC12345", "A1234567Z", "AB12345678",
          "AB12345", "AB 1234567 Z", "ab1234567z" "@XY1234567Z"]
 
         for invalid_license in invalid_licenes:

--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -11,8 +11,13 @@ class TestTeam_not_like_us(unittest.TestCase):
 
     def test_it_driver_license(self):
         """Test IT_DRIVER_LICENSE functionality"""
-        # Will Walton: Positive Test Case
-        test_string = "License number: BA1234567Z"
+        # Will Walton: Positive Test Case Refinements
+        prefix = "BA"
+        numbers = "1234567"
+        suffix = "Z"
+
+        license_num = prefix + numbers + suffix #Build Valid Format
+        test_string = f"License number: {license_num}"
         result = analyze_text(test_string, ["IT_DRIVER_LICENSE"])
 
         #Unittest to check that it found something

--- a/test_team_not_like_us.py
+++ b/test_team_not_like_us.py
@@ -11,7 +11,15 @@ class TestTeam_not_like_us(unittest.TestCase):
 
     def test_it_driver_license(self):
         """Test IT_DRIVER_LICENSE functionality"""
+        # Will Walton: Positive Test Case
+        test_string = "License number: BA1234567Z"
+        result = analyze_text(test_string, ["IT_DRIVER_LICENSE"])
 
+        #Unittest to check that it found something
+        self.assertTrue(len(result)>0, "Result is empty - license not detected")
+        self.assertEqual(result[0].entity_type, "IT_DRIVER_LICENSE")
+
+        #Negative Test Case 
     def test_it_fiscal_code(self):
         """Test IT_FISCAL_CODE functionality"""
 


### PR DESCRIPTION
Added positive test case for IT_DRIVER_LICENSE that:
- Tests valid Italian driver's license format (BA1234567Z)
- Verifies correct detection using analyze_text
- Includes assertions to check results
- Added clear comments and error messages

Negative test case For IT_DRIVER_LICENSE:
- Tests invalid Italian driver's license formats

              - 123456789 (missing letters)
              - ABC12345 (too many letters)
              - A1234567Z (only one starting letter)
              - AB12345678 (missing final letter)
              - AB12345 (too short)
              - AB 1234567 Z (spaces included)
              - ab1234567z (lowercase letters)
              - @XY1234567Z (Special character)
              

- Verifies the correct detection using analyze_text
- Use assertions to check results
- utilize clear comments and error messaging 